### PR TITLE
Minor fail  safe added

### DIFF
--- a/backend/app/context.py
+++ b/backend/app/context.py
@@ -8,6 +8,9 @@ import random
 """
 This section sets up default values for StoryContext.
 """
+# Tag File Name
+tag_file_name = 'tags.json'
+
 # Basic Constant
 max_text_length = 1000
 num_of_choices = 3
@@ -53,8 +56,7 @@ class StoryContext:
         # Save story tag JSON file
         try:
             directory = os.path.dirname(os.path.abspath(__file__))
-            # TODO - Should file name be hardcoded like this?
-            json_path = os.path.join(directory, 'tags.json')
+            json_path = os.path.join(directory, tag_file_name)
             with open(json_path, 'r') as file:
                 self.tag_weights = json.load(file)
         except FileNotFoundError:
@@ -171,7 +173,8 @@ class StoryContext:
             for key in self.choice_options:
                 self.choice_options[key].add("climax")
             self.climax = True
-    # TODO - Perhaps warn prompt ahead of time when context coming
+    # TODO - OPTIONAL.  Use int instead of bool
+    # This would let us account for scene leading to climax
 
     # --------------------------------------------------
     #                       Updating Context
@@ -222,12 +225,13 @@ def split_choices(input_string):
     """
     choices = input_string.split("!!")
     story_text = choices[0].strip()
-    choice_1 = choices[1].strip()
-    choice_2 = choices[2].strip()
-    choice_3 = "!!".join(choices[3:]).strip()
+
+    # Save choices (make blank if parsing error and not enough options made)
+    choice_1 = choices[1].strip() if len(choices) > 1 else ""
+    choice_2 = choices[2].strip() if len(choices) > 2 else ""
+    choice_3 = "!!".join(choices[3:]).strip() if len(choices) > 3 else ""
 
     return story_text, choice_1, choice_2, choice_3
-    # TODO - what's the back-up if GPT does not make a !! divider?
 
 
 # **************************************************

--- a/backend/app/helpers.py
+++ b/backend/app/helpers.py
@@ -106,7 +106,7 @@ def _describe_choices(context: StoryContext):
     )
 
     choices = ""
-    print(context.choice_options)
+
     for _, tags_set in context.choice_options.items():
         tags = list(tags_set)
         choice_text = (
@@ -115,12 +115,12 @@ def _describe_choices(context: StoryContext):
         )
         choices += choice_text
 
-    instructions = (
+    clarification = (
         "Avoid any text after the choices are given "
         "and use !! instead of numbers for each option. "
     )
 
-    return setup + choices + instructions
+    return setup + choices + clarification
 
 
 # **************************************************


### PR DESCRIPTION
When splitting choice from story, it assumes three options will be pulled from the text.  If ChatGPT's response omits the correct number of "!!"s the entire thing could crash due to an indexing error.  I added in a fail safe that defaults the options to nothing if this problem were to occur to avoid a crash.

Additionally, I replaced "tags.json" with a variable and defined it at the top of  the page.  I don't want to hardcode a file name in the middle of function and this makes it easier to change in the future.

Only four TODOs remain in the code.
1. Changing climax to an int instead of bool (optional)
2. Changing climax description to account for this change
3. Fixing the routes to avoid redundancy in main
4. Updating tag weights

None of these should have any impact on how things function and can be safely ignored unless we decide to fine tune stories.